### PR TITLE
Add support for framework distribution via Swift Package Manager.

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
         .library(
             name: "Collections",
             type: .static,
-            targets: ["Collections"]),
+            targets: ["Collections"]
+        ),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,13 @@ let package = Package(
     products: [
         .library(
             name: "Collections",
+            type: .static,
             targets: ["Collections"]),
     ],
     targets: [
         .target(
             name: "Collections",
-                path: "Collections/Collections/"
+            path: "Collections/Collections/"
         ),
         .testTarget(
             name: "CollectionTests",

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Collections",
+    platforms: [
+        .macOS(.v10_13), .iOS(.v12),
+    ],
+    products: [
+        .library(
+            name: "Collections",
+            targets: ["Collections"]),
+    ],
+    targets: [
+        .target(
+            name: "Collections",
+                path: "Collections/Collections/"
+        ),
+        .testTarget(
+            name: "CollectionTests",
+            dependencies: ["Collections"],
+            path: "Collections/CollectionsTests/"
+        ),
+    ]
+)


### PR DESCRIPTION
## What were done

- Created `Package.swift` file:
   - Explicitly specified the `static` type of library.