### PR TITLE
Integrate `Collections` framework via Swift Package Manager into `DemoApp`.

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A5113E762BFE783D0011B5E5 /* Collections.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5113E752BFE783D0011B5E5 /* Collections.xcframework */; };
 		A568BE392BF3650E001D7589 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A568BE382BF3650E001D7589 /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -34,7 +33,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A5113E762BFE783D0011B5E5 /* Collections.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A52C241C2C0100E900A9D5E3 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = A52C241B2C0100E900A9D5E3 /* Collections */; };
 		A568BE392BF3650E001D7589 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A568BE382BF3650E001D7589 /* main.swift */; };
+		A5A40A2D2C014A8A0047A7D9 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = A5A40A2C2C014A8A0047A7D9 /* Collections */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,7 +33,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A52C241C2C0100E900A9D5E3 /* Collections in Frameworks */,
+				A5A40A2D2C014A8A0047A7D9 /* Collections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -73,7 +73,7 @@
 			);
 			name = DemoApp;
 			packageProductDependencies = (
-				A52C241B2C0100E900A9D5E3 /* Collections */,
+				A5A40A2C2C014A8A0047A7D9 /* Collections */,
 			);
 			productName = DemoApp;
 			productReference = A5113E782BFE783D0011B5E5 /* DemoApp */;
@@ -104,7 +104,7 @@
 			);
 			mainGroup = A568BE2C2BF3650E001D7589;
 			packageReferences = (
-				A52C241A2C0100E900A9D5E3 /* XCLocalSwiftPackageReference ".." */,
+				A5A40A2B2C014A8A0047A7D9 /* XCLocalSwiftPackageReference ".." */,
 			);
 			productRefGroup = A568BE2C2BF3650E001D7589;
 			projectDirPath = "";
@@ -289,14 +289,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		A52C241A2C0100E900A9D5E3 /* XCLocalSwiftPackageReference ".." */ = {
+		A5A40A2B2C014A8A0047A7D9 /* XCLocalSwiftPackageReference ".." */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ..;
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		A52C241B2C0100E900A9D5E3 /* Collections */ = {
+		A5A40A2C2C014A8A0047A7D9 /* Collections */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Collections;
 		};

--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A52C241C2C0100E900A9D5E3 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = A52C241B2C0100E900A9D5E3 /* Collections */; };
 		A568BE392BF3650E001D7589 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A568BE382BF3650E001D7589 /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -33,6 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A52C241C2C0100E900A9D5E3 /* Collections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,6 +82,9 @@
 			dependencies = (
 			);
 			name = DemoApp;
+			packageProductDependencies = (
+				A52C241B2C0100E900A9D5E3 /* Collections */,
+			);
 			productName = DemoApp;
 			productReference = A5113E782BFE783D0011B5E5 /* DemoApp */;
 			productType = "com.apple.product-type.tool";
@@ -108,6 +113,9 @@
 				Base,
 			);
 			mainGroup = A568BE2C2BF3650E001D7589;
+			packageReferences = (
+				A52C241A2C0100E900A9D5E3 /* XCLocalSwiftPackageReference ".." */,
+			);
 			productRefGroup = A568BE2C2BF3650E001D7589;
 			projectDirPath = "";
 			projectRoot = "";
@@ -289,6 +297,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		A52C241A2C0100E900A9D5E3 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A52C241B2C0100E900A9D5E3 /* Collections */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Collections;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = A568BE2D2BF3650E001D7589 /* Project object */;
 }

--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		A5113E752BFE783D0011B5E5 /* Collections.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Collections.xcframework; path = Frameworks/Collections.xcframework; sourceTree = "<group>"; };
 		A5113E782BFE783D0011B5E5 /* DemoApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = DemoApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		A568BE382BF3650E001D7589 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -41,19 +40,10 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		A5113E742BFE783D0011B5E5 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				A5113E752BFE783D0011B5E5 /* Collections.xcframework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		A568BE2C2BF3650E001D7589 = {
 			isa = PBXGroup;
 			children = (
 				A568BE372BF3650E001D7589 /* DemoApp */,
-				A5113E742BFE783D0011B5E5 /* Frameworks */,
 				A5113E782BFE783D0011B5E5 /* DemoApp */,
 			);
 			sourceTree = "<group>";

--- a/DemoApp/Frameworks/Collections.xcframework/Info.plist
+++ b/DemoApp/Frameworks/Collections.xcframework/Info.plist
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8397fb66bb9ee83330556fb3f6612e24dbee70eabae6636292f4a28e71199e52
-size 1629

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Collections
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Collections
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d43bf3de9ad8768a68d64ecaa5acc36b9e5deac2eeba22e8d6924dea90511227
-size 22752

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Headers/Collections.h
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Headers/Collections.h
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf12904c1398417769dd365593829ddf73b668028255af138bbb83cf22404b3
-size 241

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Info.plist
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Info.plist
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8bab0d20990d279367a3896dca067d1319d36327c090a42baba2bad147c1428
-size 762

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab0eee38dccf8b0e56b91ba910236758a490a29ddd718926de7445f5e3d2acc6
-size 1149

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99cd10c4ac2cf91a819e48adee7073a2185e4ff739168f45bf2bf39f7492c554
-size 6632

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab0eee38dccf8b0e56b91ba910236758a490a29ddd718926de7445f5e3d2acc6
-size 1149

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/module.modulemap
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64/Collections.framework/Modules/module.modulemap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:700cbd5ada09d696c2db29fa70f155f6acb209f7dd8063b06c3976cbda2d0c97
-size 103

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Collections
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Collections
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cad4d2b98995d6086f3a42dffbfe888bf7e89816f885e73d335b379e3e9c0443
-size 46184

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Headers/Collections.h
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Headers/Collections.h
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf12904c1398417769dd365593829ddf73b668028255af138bbb83cf22404b3
-size 241

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Info.plist
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Info.plist
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0f86fd33e0de9ecb129d269d76765efcd99f4d694f79c5f3470f17ff27f104f
-size 742

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a631a46bdc210d227109500b6f012330f7298300beb6a46759a6f0bd8754a79b
-size 1159

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0c884f04d0bce8b854f22e2ce66feae5cc0469dae307808c8e3b84551a01d21
-size 6644

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a631a46bdc210d227109500b6f012330f7298300beb6a46759a6f0bd8754a79b
-size 1159

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ae2f8b6b927e10fa8d6117d21f5ad7e7af766d81c79f40ffbd4bfc3f3b5885a
-size 1160

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f11ba4c680e5b9b6fd9107bacd5efe749c591ce49209a38e5327b3dae0ef809
-size 6644

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ae2f8b6b927e10fa8d6117d21f5ad7e7af766d81c79f40ffbd4bfc3f3b5885a
-size 1160

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/module.modulemap
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/Modules/module.modulemap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:700cbd5ada09d696c2db29fa70f155f6acb209f7dd8063b06c3976cbda2d0c97
-size 103

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeDirectory
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeDirectory
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1c9f3ef61a7c34add7f7a83ce564964aeac3842d2de0718d03b9a1b4d7cc4b7
-size 247

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeRequirements
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeRequirements
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:987920904eab650e75788c054aa0b0524e6a80bfc71aa32df8d237a61743f986
-size 12

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeRequirements-1
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeRequirements-1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81f3083ad7324db79a14ebaa95954f51628ece26a2cbaa4e499fd69bfa59d530
-size 307

--- a/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeResources
+++ b/DemoApp/Frameworks/Collections.xcframework/ios-arm64_x86_64-simulator/Collections.framework/_CodeSignature/CodeResources
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86be7acaa3eebd42f1b4847b22f8462b6cccd82f7306791a60cbb1b62169d2b5
-size 6414

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Collections
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Collections
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48c928509463b2b548387682203eb2b8b2362f8dbf7af95a5b3aacd068b3c493
-size 47480

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Headers/Collections.h
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Headers/Collections.h
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf12904c1398417769dd365593829ddf73b668028255af138bbb83cf22404b3
-size 241

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c1c51f83380d28af125bc68a0f437590b865dd0ae7c29aca41cca1d204ea978
-size 1152

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:739e5810a96d6361c2fd30ff249630aa21fe90175baea038c3a24597e0d56f46
-size 6636

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c1c51f83380d28af125bc68a0f437590b865dd0ae7c29aca41cca1d204ea978
-size 1152

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ba0cb2382404351c4f401e0ceb35eee0dd3e175a887fff669052d4eac2b1006
-size 1153

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e65ba6ed9b88029f6cb6c15410a0335b289f0a17debdd872b0f80c98a7441c04
-size 6636

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ba0cb2382404351c4f401e0ceb35eee0dd3e175a887fff669052d4eac2b1006
-size 1153

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/module.modulemap
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Modules/module.modulemap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:700cbd5ada09d696c2db29fa70f155f6acb209f7dd8063b06c3976cbda2d0c97
-size 103

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Resources/Info.plist
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Resources/Info.plist
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66e65ab8bf92c71f7fe190016ccf8638d8e65bc98eae0c55db8c8643dfcb4b44
-size 1266

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Collections
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Collections
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48c928509463b2b548387682203eb2b8b2362f8dbf7af95a5b3aacd068b3c493
-size 47480

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Headers/Collections.h
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Headers/Collections.h
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf12904c1398417769dd365593829ddf73b668028255af138bbb83cf22404b3
-size 241

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c1c51f83380d28af125bc68a0f437590b865dd0ae7c29aca41cca1d204ea978
-size 1152

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:739e5810a96d6361c2fd30ff249630aa21fe90175baea038c3a24597e0d56f46
-size 6636

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c1c51f83380d28af125bc68a0f437590b865dd0ae7c29aca41cca1d204ea978
-size 1152

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ba0cb2382404351c4f401e0ceb35eee0dd3e175a887fff669052d4eac2b1006
-size 1153

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e65ba6ed9b88029f6cb6c15410a0335b289f0a17debdd872b0f80c98a7441c04
-size 6636

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ba0cb2382404351c4f401e0ceb35eee0dd3e175a887fff669052d4eac2b1006
-size 1153

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/module.modulemap
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Modules/module.modulemap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:700cbd5ada09d696c2db29fa70f155f6acb209f7dd8063b06c3976cbda2d0c97
-size 103

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Resources/Info.plist
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/Resources/Info.plist
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66e65ab8bf92c71f7fe190016ccf8638d8e65bc98eae0c55db8c8643dfcb4b44
-size 1266

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeDirectory
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeDirectory
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c3199d72ffae6a08e01346ef26b9a38674ac1b81cd284b68ec01ee778a78c35
-size 247

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeRequirements
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeRequirements
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:987920904eab650e75788c054aa0b0524e6a80bfc71aa32df8d237a61743f986
-size 12

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeRequirements-1
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeRequirements-1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bb2af417eaa36dd99233340904c812b4417823eb92946e921d16c2722650130
-size 307

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeResources
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/A/_CodeSignature/CodeResources
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84bb8f557c9ea61470d29e4913a4450647191b3eabd4292603a30c89deb09fda
-size 5518

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Collections
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Collections
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48c928509463b2b548387682203eb2b8b2362f8dbf7af95a5b3aacd068b3c493
-size 47480

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Headers/Collections.h
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Headers/Collections.h
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf12904c1398417769dd365593829ddf73b668028255af138bbb83cf22404b3
-size 241

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c1c51f83380d28af125bc68a0f437590b865dd0ae7c29aca41cca1d204ea978
-size 1152

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:739e5810a96d6361c2fd30ff249630aa21fe90175baea038c3a24597e0d56f46
-size 6636

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c1c51f83380d28af125bc68a0f437590b865dd0ae7c29aca41cca1d204ea978
-size 1152

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.abi.json
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.abi.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2224077abfeac72a38ff9ea0df6c91f2307fd4b758e36458bbf48d9fa4e123c7
-size 18756

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.private.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.private.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ba0cb2382404351c4f401e0ceb35eee0dd3e175a887fff669052d4eac2b1006
-size 1153

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftdoc
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftdoc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e65ba6ed9b88029f6cb6c15410a0335b289f0a17debdd872b0f80c98a7441c04
-size 6636

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/Collections.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ba0cb2382404351c4f401e0ceb35eee0dd3e175a887fff669052d4eac2b1006
-size 1153

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/module.modulemap
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Modules/module.modulemap
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:700cbd5ada09d696c2db29fa70f155f6acb209f7dd8063b06c3976cbda2d0c97
-size 103

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Resources/Info.plist
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/Resources/Info.plist
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66e65ab8bf92c71f7fe190016ccf8638d8e65bc98eae0c55db8c8643dfcb4b44
-size 1266

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeDirectory
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeDirectory
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c3199d72ffae6a08e01346ef26b9a38674ac1b81cd284b68ec01ee778a78c35
-size 247

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeRequirements
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeRequirements
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:987920904eab650e75788c054aa0b0524e6a80bfc71aa32df8d237a61743f986
-size 12

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeRequirements-1
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeRequirements-1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bb2af417eaa36dd99233340904c812b4417823eb92946e921d16c2722650130
-size 307

--- a/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeResources
+++ b/DemoApp/Frameworks/Collections.xcframework/macos-arm64_x86_64/Collections.framework/Versions/Current/_CodeSignature/CodeResources
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84bb8f557c9ea61470d29e4913a4450647191b3eabd4292603a30c89deb09fda
-size 5518


### PR DESCRIPTION
Please note: This PR depends on(MUST be merged ONLY AFTER):

- #29 

## What were done

- Removed `Frameworks` folder with `Collections.xcframework`
- Removed `Collections.xcframework` from target dependencies.
- Integrated `Collections` framework via Swift Package Manager into `DemoApp`.