### PR TITLE
Bump marketing version to `0.2.0`

### DIFF
--- a/collections/Collections.xcodeproj/project.pbxproj
+++ b/collections/Collections.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				);
 				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = auhustsinovich.framework.multiplatform.collections;
@@ -530,7 +530,7 @@
 				);
 				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = auhustsinovich.framework.multiplatform.collections;


### PR DESCRIPTION
## What were done 

- Changed marketing version of `Collections` framework to `0.2.0`.